### PR TITLE
Add open-ssh-tunnel

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,4 @@
 * [hash-to-port](https://github.com/mafintosh/hash-to-port) – Hash a value to a valid port.
 * [magnet-uri](https://github.com/feross/magnet-uri) – Parse a magnet URI and return an object of keys/values.
 * [geocode-wifi](https://github.com/watson/geocode-wifi) – Get yours latitude/longitude based on your wifi access point.
+* [open-ssh-tunnel](https://github.com/parro-it/open-ssh-tunnel) – Easy ssh2 tunneling.


### PR DESCRIPTION
open-ssh-tunnel is a function based on ssh2 library that let's you open an ssh tunnel to a remote machine.
